### PR TITLE
Publish with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,13 +2,15 @@ name: Publish
 
 on:
   push:
-    tags: '*'
+    tags:
+      - '*'
 
 jobs:
   deploy:
-
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write  # this permission is mandatory for trusted publishing
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -19,9 +21,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install poetry poetry-dynamic-versioning twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Build
       run: |
-        poetry publish --build --username $TWINE_USERNAME --password $TWINE_PASSWORD
+        poetry build
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I think we should use OIDC instead of username and password

https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect