### PR TITLE
Fix default schema file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ unit test example is [here](https://github.com/gyuta/bqemulatormanager/blob/main
 ### automatically detect schema
 When called `Manager.load`, `SchemaManager` search correspond table schema from `schema_path` (default is `bqem_master_schema.yaml`).
 
-If schema definition canot be found, `SchemaManager` request it from BigQuery in production environmant and update master schema file.
+If schema definition cannot be found, `SchemaManager` request it from BigQuery in production environment and update master schema file.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ print(df)
 unit test example is [here](https://github.com/gyuta/bqemulatormanager/blob/main/examples/testing.py).
 
 ### automatically detect schema
-When called `Manager.load`, `SchemaManager` search correspond table schema from `schema_path` (default is `master_schema.yaml`).
+When called `Manager.load`, `SchemaManager` search correspond table schema from `schema_path` (default is `bqem_master_schema.yaml`).
 
 If schema definition canot be found, `SchemaManager` request it from BigQuery in production environmant and update master schema file.

--- a/bqemulatormanager/manager.py
+++ b/bqemulatormanager/manager.py
@@ -19,7 +19,7 @@ class Manager:
         project: str = "test",
         port: int = 9050,
         grpc_port: int = 9060,
-        schema_path: str = "master_schema.yaml",
+        schema_path: str = "bqem_master_schema.yaml",
         launch_emulator: bool = True,
         debug_mode: bool = False,
         max_pool: int = 20,


### PR DESCRIPTION
fixes up https://github.com/m3dev/bqemulatormanager/pull/12

In the PR we renamed the default master schema file from `master_schema.yaml` to `bqem_master_schema.yaml`, but there were modifications missing.